### PR TITLE
EARTH-1: Template tweaks.

### DIFF
--- a/patterns/molecules/film-card/css/film-card.component.css
+++ b/patterns/molecules/film-card/css/film-card.component.css
@@ -33,6 +33,7 @@
 
 .film-card .film-card__caption {
   position: absolute;
+  max-width: 180px;
   margin: 55px 4px 55px 22px;
   color: #fff;
 }

--- a/patterns/molecules/film-card/film-card.html.twig
+++ b/patterns/molecules/film-card/film-card.html.twig
@@ -5,13 +5,16 @@
  */
 #}
 <div class="film-card">
-  <a class="film-card__link" href="{{ link }}">
+  {% if link is not empty %}
+  <a class="film-card__link" href="{{ link|render|striptags|trim }}">
+  {% endif %}
     <div class="film-card__thumbnail">
         {{ image }}
     </div>
     <div class="film-card__caption">
-      <h6>{{ title }}</h6>
+      <h6>{{ title|render|striptags|trim }}</h6>
     </div>
+    {% if link is not empty %}
     <div class="film-card__arrow">
         <svg version="1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
              viewBox="0 0 24 13" style="enable-background:new 0 0 24 13;" xml:space="preserve">
@@ -26,4 +29,5 @@ s-0,0-0,0l-5,5C18,12,18,12,18,12z"/>
       </svg>
     </div>
   </a>
+  {% endif %}
 </div>

--- a/patterns/molecules/film-card/film-card.ui_patterns.yml
+++ b/patterns/molecules/film-card/film-card.ui_patterns.yml
@@ -2,7 +2,7 @@
 #
 film_card:
   label: Film card
-  description: A single card inside a filmstrip
+  description: A single card inside a filmstrip.
   fields:
     image:
       type: text
@@ -10,7 +10,7 @@ film_card:
       description: Card image.
       preview:
         theme: image
-        uri: http://lorempixel.com/400/200/sports/6
+        uri: https://lorempixel.com/400/200/sports/6
         alt: this is a sample image
     title:
       type: text
@@ -19,9 +19,9 @@ film_card:
       preview: Card title
     link:
       type: text
-      label: Link
-      description: URI that points somewhere
-      preview: http://stanford.edu
+      label: Link (optional)
+      description: URI that points somewhere.
+      preview: https://stanford.edu/
   libraries:
     - film_card_library:
         css:

--- a/patterns/molecules/film-card/film-card.ui_patterns.yml
+++ b/patterns/molecules/film-card/film-card.ui_patterns.yml
@@ -5,7 +5,7 @@ film_card:
   description: A single card inside a filmstrip
   fields:
     image:
-      type: image
+      type: text
       label: Image
       description: Card image.
       preview:
@@ -18,7 +18,7 @@ film_card:
       description: Card title.
       preview: Card title
     link:
-      type: url
+      type: text
       label: Link
       description: URI that points somewhere
       preview: http://stanford.edu

--- a/patterns/molecules/film-card/scss/film-card.component.scss
+++ b/patterns/molecules/film-card/scss/film-card.component.scss
@@ -29,6 +29,7 @@
 
   .film-card__caption {
     position: absolute;
+    max-width: 180px;
     margin: 55px 4px 55px 22px;
     color: #fff;
   }

--- a/patterns/molecules/filmstrip/css/filmstrip.theme.css
+++ b/patterns/molecules/filmstrip/css/filmstrip.theme.css
@@ -15,11 +15,8 @@
   margin: 12px 0 17px;
 }
 
-@media (min-width: 768px) {
-  .filmstrip h6.filmstrip__title {
-    color: #fff;
-    background: rgba(100, 100, 100, 0.3);
-  }
+.filmstrip h6.white-text {
+  color: #fff;
 }
 
 /*# sourceMappingURL=filmstrip.theme.css.map */

--- a/patterns/molecules/filmstrip/filmstrip.html.twig
+++ b/patterns/molecules/filmstrip/filmstrip.html.twig
@@ -9,7 +9,7 @@
 {# Template HTML #}
 <div class="filmstrip">
   <div class="filmstrip__top_border"></div>
-  <h6 class="filmstrip__title">{{ title }}</h6>
+  <h6 class="filmstrip__title white-text">{{ title }}</h6>
   <div class="filmstrip__cards">
     {# Break up the individual items in to the appropriate template var. #}
     {% for item in items %}
@@ -22,5 +22,7 @@
       {# Pass vars through to include template. #}
       {% include '@stanford_components/molecules/film-card/film-card.html.twig' with vars %}
     {% endfor %}
+    {# When Drupal Provides the film cards use this region. #}
+    {{ content }}
   </div>
 </div>

--- a/patterns/molecules/filmstrip/filmstrip.ui_patterns.yml
+++ b/patterns/molecules/filmstrip/filmstrip.ui_patterns.yml
@@ -2,44 +2,44 @@
 #
 filmstrip:
   label: Filmstrip
-  description: A horizontal list of small images with text overlays and arrow buttons
+  description: A horizontal list of small images with text overlays and arrow buttons.
   fields:
     title:
       type: text
       label: Title
-      description: Title for the whole filmstrip
+      description: Title for the whole filmstrip.
       preview: Challenges We Tackle
     items:
-      type: array
-      label: A list of simple image cards
+      type: collection
+      label: A list of simple image cards (optional)
       description: This template iterates over the items to produce a nested unordered list of divs. Each item must have a url, title, and an image rendered as an html element.
       preview:
         -
           link: https://www.stanford.edu
           image:
             theme: image
-            uri: http://lorempixel.com/220/145/sports/1
+            uri: https://lorempixel.com/220/145/sports/1
             alt: this is a sample image
           title: First Item
         -
           link: https://www.stanford.edu
           image:
             theme: image
-            uri: http://lorempixel.com/220/145/sports/5
+            uri: https://lorempixel.com/220/145/sports/5
             alt: this is a sample image
           title: Second Item
         -
           link: https://www.stanford.edu
           image:
             theme: image
-            uri: http://lorempixel.com/220/145/sports/2
+            uri: https://lorempixel.com/220/145/sports/2
             alt: this is a sample image
           title: Third Item
     content:
       type: text
-      label: Rendered Markup
+      label: Rendered Markup (optional)
       description: The rendered html markup for the items if using a view or something else that will already provide the templated output.
-      preview: 
+      preview:
   libraries:
     - filmstrip_library:
         css:

--- a/patterns/molecules/filmstrip/filmstrip.ui_patterns.yml
+++ b/patterns/molecules/filmstrip/filmstrip.ui_patterns.yml
@@ -35,6 +35,11 @@ filmstrip:
             uri: http://lorempixel.com/220/145/sports/2
             alt: this is a sample image
           title: Third Item
+    content:
+      type: text
+      label: Rendered Markup
+      description: The rendered html markup for the items if using a view or something else that will already provide the templated output.
+      preview: 
   libraries:
     - filmstrip_library:
         css:

--- a/patterns/molecules/filmstrip/scss/filmstrip.component.scss
+++ b/patterns/molecules/filmstrip/scss/filmstrip.component.scss
@@ -12,7 +12,6 @@
       margin: 0 18px 20px 0;
       text-align: left;
     }
-
   }
 
   .film-card {

--- a/patterns/molecules/filmstrip/scss/filmstrip.theme.scss
+++ b/patterns/molecules/filmstrip/scss/filmstrip.theme.scss
@@ -15,13 +15,10 @@
 
     &.filmstrip__title {
       margin: 12px 0 17px;
+    }
 
-      @media (min-width: 768px){
-        color: #fff;
-        // Extra special styling for patterns preview
-        background: rgba(100, 100, 100, .3);
-      }
+    &.white-text {
+      color: #fff;
     }
   }
 }
-


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
Just some small tweaks to the component film-card and film-strip templates.
* https everywhere
* Punctuation.
* Added filters to title and url fields on film-card to ensure no markup is added
* Made the url field optional on film card

# Needed By (Date)
- 2017.06.14

# Urgency
- Would be nice to have sooner rather than later.

# Steps to Test

1. Check out this branch and clear caches
2. Visit /patterns and read description text
3. Ensure film-card and film-strip still look good
4. Add film card template to a block/paragraph/whatever
5. Create a block/paragraph/whatever and review markup

# Affected Projects or Products
- Will be needed for CTA feature.

# Associated Issues and/or People
- EARTH-91
- @josephgknox FYI

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)