### PR TITLE
EARTH-139: Added output trimming to hero banner type.

### DIFF
--- a/patterns/molecules/hero-banner/hero-banner.html.twig
+++ b/patterns/molecules/hero-banner/hero-banner.html.twig
@@ -5,19 +5,19 @@
  */
 #}
 <!-- Start hero-banner component //-->
-<div class="hero-banner has-tint" style="background-image:url({{ image }})">
+<div class="hero-banner has-tint" style="background-image:url({{ image|render|striptags|trim }})">
   <div class="hero-banner__inner is-tall">
     <div class="hero-banner__container">
       <div class="hero-banner__header is-right">
 
         {% if ispagetitle == true %}
-        <h1 class="hero-banner__title h1 page-title">{{ superhead }}</h1>
+        <h1 class="hero-banner__title h1 page-title">{{ superhead|render|striptags|trim }}</h1>
         {% else %}
-        <h2 class="hero-banner__title h1">{{ superhead }}</h2>
+        <h2 class="hero-banner__title h1">{{ superhead|render|striptags|trim }}</h2>
         {% endif %}
 
         {% if subhead is not null and subhead is not empty %}
-        <p>{{ subhead }}</p>
+        <p>{{ subhead|render|striptags|trim }}</p>
         {% endif %}
 
         {% if cite is not null and cite is not empty %}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary

Please review all 5 PRs at once:
- https://github.com/SU-SWS/stanford_paragraph_types/pull/34
- https://github.com/SU-SWS/stanford_components/pull/8
- https://github.com/SU-SWS/stanford_complex_page/pull/3
- https://github.com/stanford-earth/matson/pull/23/files
- https://github.com/stanford-earth/SE3_BLT/pull/8/files

The above 5 PRs do the following
- Implements the hero banner for complex page.
- Removes page title on node types
- Removes old testing hero paragraph type
- Creates new hero banner paragraph type
- Adds new css for hero banners so they have the correct placement under the menu
- Adds css for the edit tabs so they don't get lost
- Enables new hero banner paragraph type module
- Enables scheduled publishing and unpublishing on complex page type
- Enables xml sitemap for complex page content type

# Needed By (Date)
- Soonish would be better. Nick wants to build out stuff.

# Urgency
- Moderate

# Steps to Test

1. Check out all of the above branches. They should all be named hero-banner
2. Do a local refresh
3. validate the above list of changes
4. Create and place a new hero banner paragraph type

# Associated Issues and/or People
- EARTH-139

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)