### PR TITLE
EARTH-138: Added templates to patterns for use in paragraphs.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,6 +8,13 @@ module.exports = function(grunt) {
     pkg: grunt.file.readJSON('package.json'),
     watch: {
       // This is where we set up all the tasks we'd like grunt to watch for changes.
+      scripts: {
+        files: ['js/source/**/*.js'],
+        tasks: ['uglify', 'drush:ccall'],
+        options: {
+          spawn: false,
+        },
+      },
       images: {
         files: ['**/*.{png,jpg,gif}'],
         tasks: ['imagemin'],
@@ -90,7 +97,8 @@ module.exports = function(grunt) {
       dist: {
         files: {
           // Atoms.
-          // Nothing yet.
+          'patterns/atoms/link-item/css/link-item.component.css':                             'patterns/atoms/link-item/scss/link-item.component.scss',
+          'patterns/atoms/icon-item/css/icon-item.component.css':                             'patterns/atoms/icon-item/scss/icon-item.component.scss',
           // Molecules.
           'patterns/molecules/simple-card/css/simple-card.component.css':                     'patterns/molecules/simple-card/scss/simple-card.component.scss',
           'patterns/molecules/simple-card/css/simple-card.theme.css':                         'patterns/molecules/simple-card/scss/simple-card.theme.scss',
@@ -106,16 +114,24 @@ module.exports = function(grunt) {
           'patterns/molecules/callout-blocks/css/callout-blocks.component.css':               'patterns/molecules/callout-blocks/scss/callout-blocks.component.scss',
           'patterns/molecules/callout-cards/css/callout-cards.component.css':                 'patterns/molecules/callout-cards/scss/callout-cards.component.scss',
           'patterns/molecules/section-header/css/section-header.component.css':               'patterns/molecules/section-header/scss/section-header.component.scss',
+          'patterns/molecules/link-banner/css/link-banner.component.css':                     'patterns/molecules/link-banner/scss/link-banner.component.scss',
           'patterns/molecules/feature-card/css/feature-card.component.css':                   'patterns/molecules/feature-card/scss/feature-card.component.scss',
           'patterns/molecules/feature-cards/css/feature-cards.component.css':                 'patterns/molecules/feature-cards/scss/feature-cards.component.scss',
+          'patterns/molecules/highlight-card/css/highlight-card.component.css':               'patterns/molecules/highlight-card/scss/highlight-card.component.scss',
+          'patterns/molecules/highlight-cards/css/highlight-cards.component.css':             'patterns/molecules/highlight-cards/scss/highlight-cards.component.scss',
+          'patterns/molecules/expandable-card/css/expandable-card.component.css':             'patterns/molecules/expandable-card/scss/expandable-card.component.scss',
+          'patterns/molecules/expandable-card/css/expandable-card.states.css':                'patterns/molecules/expandable-card/scss/expandable-card.states.scss',
+          'patterns/molecules/expandable-cards/css/expandable-cards.component.css':           'patterns/molecules/expandable-cards/scss/expandable-cards.component.scss',
           // Organisms.
-          'patterns/organisms/section-callout-filmstrip/css/section-callout-filmstrip.component.css': 'patterns/organisms/section-callout-filmstrip/scss/section-callout-filmstrip.component.scss',
-          'patterns/organisms/section-callout-cards/css/section-callout-cards.component.css':         'patterns/organisms/section-callout-cards/scss/section-callout-cards.component.scss',
-          'patterns/organisms/section-callout-blocks/css/section-callout-blocks.component.css':       'patterns/organisms/section-callout-blocks/scss/section-callout-blocks.component.scss',
-          'patterns/organisms/section-feature-cards/css/section-feature-cards.component.css':         'patterns/organisms/section-feature-cards/scss/section-feature-cards.component.scss',
+          'patterns/organisms/section-callout-filmstrip/css/section-callout-filmstrip.component.css':   'patterns/organisms/section-callout-filmstrip/scss/section-callout-filmstrip.component.scss',
+          'patterns/organisms/section-callout-cards/css/section-callout-cards.component.css':           'patterns/organisms/section-callout-cards/scss/section-callout-cards.component.scss',
+          'patterns/organisms/section-callout-blocks/css/section-callout-blocks.component.css':         'patterns/organisms/section-callout-blocks/scss/section-callout-blocks.component.scss',
+          'patterns/organisms/section-feature-cards/css/section-feature-cards.component.css':           'patterns/organisms/section-feature-cards/scss/section-feature-cards.component.scss',
+          'patterns/organisms/section-highlight-banner/css/section-highlight-banner.component.css':     'patterns/organisms/section-highlight-banner/scss/section-highlight-banner.component.scss',
+          'patterns/organisms/section-expandable-banner/css/section-expandable-banner.component.css':   'patterns/organisms/section-expandable-banner/scss/section-expandable-banner.component.scss',
+          'patterns/organisms/section-expandable-banner/css/section-expandable-banner.states.css':      'patterns/organisms/section-expandable-banner/scss/section-expandable-banner.states.scss',
           // Templates.
           'patterns/templates/paragraph-cta-list/css/paragraph-cta-list.component.css':         'patterns/templates/paragraph-cta-list/scss/paragraph-cta-list.component.scss'
-
         }
       }
     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -112,7 +112,10 @@ module.exports = function(grunt) {
           'patterns/organisms/section-callout-filmstrip/css/section-callout-filmstrip.component.css': 'patterns/organisms/section-callout-filmstrip/scss/section-callout-filmstrip.component.scss',
           'patterns/organisms/section-callout-cards/css/section-callout-cards.component.css':         'patterns/organisms/section-callout-cards/scss/section-callout-cards.component.scss',
           'patterns/organisms/section-callout-blocks/css/section-callout-blocks.component.css':       'patterns/organisms/section-callout-blocks/scss/section-callout-blocks.component.scss',
-          'patterns/organisms/section-feature-cards/css/section-feature-cards.component.css':         'patterns/organisms/section-feature-cards/scss/section-feature-cards.component.scss'
+          'patterns/organisms/section-feature-cards/css/section-feature-cards.component.css':         'patterns/organisms/section-feature-cards/scss/section-feature-cards.component.scss',
+          // Templates.
+          'patterns/templates/paragraph-cta-list/css/paragraph-cta-list.component.css':         'patterns/templates/paragraph-cta-list/scss/paragraph-cta-list.component.scss'
+
         }
       }
     },

--- a/patterns/atoms/icon-item/css/icon-item.component.css
+++ b/patterns/atoms/icon-item/css/icon-item.component.css
@@ -1,0 +1,17 @@
+.icon-item__image {
+  display: block;
+  float: left;
+  padding-right: 1em;
+  margin-right: 1em;
+}
+
+.icon-item__image img {
+  width: 30px;
+  height: 30px;
+}
+
+.icon-item__name {
+  margin-left: 57px;
+}
+
+/*# sourceMappingURL=icon-item.component.css.map */

--- a/patterns/atoms/icon-item/icon-item.html.twig
+++ b/patterns/atoms/icon-item/icon-item.html.twig
@@ -1,0 +1,10 @@
+{#
+/**
+ * @file
+ * Icon item pattern.
+ */
+#}
+<a class="icon-item" href="{{ link|render|striptags|trim }}">
+  <span class="icon-item__image">{{ image }}</span>
+  <h5 class="icon-item__name">{{ name }} <span class="icon-item__arrow"><svg class="i-svg i-svg--arrow-right"><use xlink:href="#i-arrow" xmlns:xlink="http://www.w3.org/1999/xlink"></use></svg></span></h5>
+</a>

--- a/patterns/atoms/icon-item/icon-item.ui_patterns.yml
+++ b/patterns/atoms/icon-item/icon-item.ui_patterns.yml
@@ -1,0 +1,31 @@
+# Icon item Pattern
+#
+icon_item:
+  label: "Icon item"
+  description: "A single of callout block"
+  fields:
+    image:
+      description: "Icon image."
+      label: Image
+      preview:
+        alt: "this is a sample image"
+        theme: image
+        uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+      type: image
+    link:
+      description: "URI that points somewhere"
+      label: Link
+      preview: "https://stanford.edu"
+      type: url
+    name:
+      description: "Item name."
+      label: Title
+      preview: "Field Learning"
+      type: text
+  libraries:
+    -
+      icon_item_library:
+        css:
+          component:
+            css/icon-item.component.css: {}
+  use: "@stanford_components/atoms/icon-item/icon-item.html.twig"

--- a/patterns/atoms/icon-item/scss/icon-item.component.scss
+++ b/patterns/atoms/icon-item/scss/icon-item.component.scss
@@ -1,0 +1,22 @@
+@charset 'UTF-8';
+
+@import 'decanter/core/utilities/decanter-utilities';
+
+// Grab our mixins.
+@import 'patterns/utilities/utilities';
+
+.icon-item__image {
+  display: block;
+  float: left;
+  padding-right: 1em;
+  margin-right: 1em;
+
+  img {
+    width: 30px;
+    height: 30px;
+  }
+}
+
+.icon-item__name {
+  margin-left: 57px;
+}

--- a/patterns/atoms/link-item/css/link-item.component.css
+++ b/patterns/atoms/link-item/css/link-item.component.css
@@ -1,0 +1,6 @@
+.link-item {
+  padding: 2em;
+  text-align: center;
+}
+
+/*# sourceMappingURL=link-item.component.css.map */

--- a/patterns/atoms/link-item/link-item.html.twig
+++ b/patterns/atoms/link-item/link-item.html.twig
@@ -1,0 +1,11 @@
+{#
+/**
+ * @file
+ * Link item pattern.
+ */
+#}
+<a href="{{ link|render|striptags|trim }}" class="link-item">
+  <h4 class="link-item__title">{{ title }}
+    <span class="link-item__subtitle">{{ subtitle }}</span>
+  </h4>
+</a>

--- a/patterns/atoms/link-item/link-item.ui_patterns.yml
+++ b/patterns/atoms/link-item/link-item.ui_patterns.yml
@@ -1,0 +1,27 @@
+# Link item
+link_item:
+  label: "Link item"
+  description: "A single link item"
+  fields:
+    link:
+      description: "URI that points somewhere"
+      label: Link
+      preview: "https://stanford.edu"
+      type: url
+    title:
+      description: "Link name."
+      label: Title
+      preview: "Link title"
+      type: text
+    subtitle:
+      description: "Link subtitle."
+      label: Subtitle
+      preview: "Link subtitle"
+      type: text
+  libraries:
+    -
+      link_item_library:
+        css:
+          component:
+            css/link-item.component.css: {}
+  use: "@stanford_components/atoms/link-item/link-item.html.twig"

--- a/patterns/atoms/link-item/scss/link-item.component.scss
+++ b/patterns/atoms/link-item/scss/link-item.component.scss
@@ -1,0 +1,11 @@
+@charset 'UTF-8';
+
+@import 'decanter/core/utilities/decanter-utilities';
+
+// Grab our mixins.
+@import 'patterns/utilities/utilities';
+
+.link-item {
+  padding: 2em;
+  text-align: center;
+}

--- a/patterns/molecules/callout-blocks/css/callout-blocks.component.css
+++ b/patterns/molecules/callout-blocks/css/callout-blocks.component.css
@@ -4,7 +4,7 @@
   display: block;
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1024px) {
   .callout-blocks {
     max-width: 830px;
     margin: 0 auto;
@@ -19,9 +19,9 @@
 
 @media only screen and (min-width: 768px) {
   .callout-blocks .callout-block {
-    width: calc(33.3333333333% - 26.6666666667px);
+    width: calc(33.3333333333% - 53.3333333333px);
     float: left;
-    margin-left: 20px;
+    margin-left: 40px;
     max-width: none;
     margin-left: 20px;
   }

--- a/patterns/molecules/callout-cards/css/callout-cards.component.css
+++ b/patterns/molecules/callout-cards/css/callout-cards.component.css
@@ -11,18 +11,18 @@
 
 @media only screen and (min-width: 768px) {
   .callout-cards .callout-card {
-    width: calc(50% - 30px);
+    width: calc(50% - 60px);
     float: left;
-    margin-left: 20px;
+    margin-left: 40px;
     min-height: 200px;
   }
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1024px) {
   .callout-cards .callout-card {
-    width: calc(25% - 25px);
+    width: calc(25% - 50px);
     float: left;
-    margin-left: 20px;
+    margin-left: 40px;
   }
 }
 

--- a/patterns/molecules/expandable-card/css/expandable-card.component.css
+++ b/patterns/molecules/expandable-card/css/expandable-card.component.css
@@ -1,0 +1,63 @@
+.expandable-card {
+  background-color: #fff;
+  max-width: 285px;
+}
+
+@media only screen and (min-width: 768px) {
+  .expandable-card.is-narrow .icon-item {
+    width: calc(50% - 60px);
+    float: left;
+    margin-left: 40px;
+  }
+  .expandable-card.is-narrow .icon-item:nth-child(2n+1) {
+    clear: both;
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .expandable-card.is-wide .icon-item {
+    width: calc(33.3333333333% - 53.3333333333px);
+    float: left;
+    margin-left: 40px;
+  }
+  .expandable-card.is-wide .icon-item:nth-child(3n+1) {
+    clear: both;
+  }
+}
+
+.expandable-card .icon-items {
+  display: none;
+}
+
+.expandable-card .icon-items::after {
+  clear: both;
+  content: "";
+  display: block;
+}
+
+.expandable-card .icon-item {
+  display: block;
+  max-width: 180px;
+  margin: 0 auto;
+  padding: 2em 0 1em;
+}
+
+@media only screen and (min-width: 768px) {
+  .expandable-card .icon-item {
+    padding: 2em 1em 1em 0;
+    max-width: none;
+  }
+}
+
+.expandable-card__open {
+  display: block;
+}
+
+.expandable-card__close {
+  display: none;
+  position: absolute;
+  top: 45px;
+  right: 30px;
+}
+
+/*# sourceMappingURL=expandable-card.component.css.map */

--- a/patterns/molecules/expandable-card/css/expandable-card.states.css
+++ b/patterns/molecules/expandable-card/css/expandable-card.states.css
@@ -1,0 +1,39 @@
+.js-expandable-card.is-open {
+  padding: 0;
+  width: 100%;
+  max-width: none;
+}
+
+.js-expandable-card.is-open .expandable-card__header {
+  padding: 0.4444444444em 1.6666666667em;
+}
+
+.js-expandable-card.is-open .expandable-card__title {
+  padding-top: 1em;
+  padding-bottom: 1em;
+}
+
+.js-expandable-card.is-open .icon-items {
+  display: block;
+  padding-bottom: 1em;
+}
+
+@media only screen and (min-width: 768px) {
+  .js-expandable-card.is-open .icon-items {
+    padding-bottom: 0;
+  }
+}
+
+.js-expandable-card.is-open .expandable-card__open {
+  display: none;
+}
+
+.js-expandable-card.is-open .expandable-card__close {
+  display: block;
+}
+
+.js-expandable-card.is-hidden {
+  display: none;
+}
+
+/*# sourceMappingURL=expandable-card.states.css.map */

--- a/patterns/molecules/expandable-card/expandable-card.html.twig
+++ b/patterns/molecules/expandable-card/expandable-card.html.twig
@@ -1,0 +1,32 @@
+{#
+/**
+ * @file
+ * Expandable card pattern.
+ */
+#}
+{{ attach_library('ui_patterns/icon_item.icon_item_library') }}
+<div class="expandable-card js-expandable-card{% if is_wide %} is-wide{% else %} is-narrow{% endif %}">
+  <header class="expandable-card__header">
+    <h4 class="expandable-card__title drop-cap-title">
+      <span class="drop-cap-title__name">{{ title }}</span> 
+      <span class="drop-cap-title__drop-cap drop-cap--is-centered" aria-hidden="true">{{ title|render|striptags|trim|slice(0, 1) }}</span>
+    </h4>
+  </header>
+
+  <div class="expandable-card__toggle js-expandable-card__toggle">
+    <span class="expandable-card__open"><svg class="i-svg i-svg--plus"><use xlink:href="#i-plus" xmlns:xlink="http://www.w3.org/1999/xlink"></use></svg></span>
+    <span class="expandable-card__close"><svg class="i-svg i-svg--minus"><use xlink:href="#i-minus" xmlns:xlink="http://www.w3.org/1999/xlink"></use></svg></span>
+  </div>
+
+  <nav class="icon-items">
+    {% for item in items %}
+      {% set vars = {
+        'link': item.link,
+        'name': item.name,
+        'image': item.image
+        }
+      %}
+      {% include '@stanford_components/atoms/icon-item/icon-item.html.twig' with vars %}
+    {% endfor %}
+  </nav>
+</div>

--- a/patterns/molecules/expandable-card/expandable-card.ui_patterns.yml
+++ b/patterns/molecules/expandable-card/expandable-card.ui_patterns.yml
@@ -1,0 +1,72 @@
+# Expandable Card Pattern
+expandable_card:
+  label: "Expandable card"
+  description: "A single expandable card"
+  fields:
+    is_wide:
+      description: "Render three column layout. Treat as boolean (true/false)."
+      label: "Three Columns"
+      preview: true
+      type: text
+    items:
+      description: "This template iterates over the items to produce a nested unordered list of divs. Each item must have a url, title, and image rendered as an html element."
+      label: "A list of highlight cards"
+      preview:
+        -
+          image:
+            alt: "this is a sample image"
+            theme: image
+            uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+          link: "https://www.stanford.edu"
+          name: "Geological Sciences"
+        -
+          image:
+            alt: "this is a sample image"
+            theme: image
+            uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+          link: "https://www.stanford.edu"
+          name: "Energy Resources Engineering"
+        -
+          image:
+            alt: "this is a sample image"
+            theme: image
+            uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+          link: "https://www.stanford.edu"
+          name: "Earth Systems Program"
+        -
+          image:
+            alt: "this is a sample image"
+            theme: image
+            uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+          link: "https://www.stanford.edu"
+          name: "Earth Systems Sciences"
+        -
+          image:
+            alt: "this is a sample image"
+            theme: image
+            uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+          link: "https://www.stanford.edu"
+          name: Geophysics
+        -
+          image:
+            alt: "this is a sample image"
+            theme: image
+            uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+          link: "https://www.stanford.edu"
+          name: "Emmett Interdisciplinary Program"
+    title:
+      description: "Card title."
+      label: Title
+      preview: "Life At The Extremes"
+      type: text
+  libraries:
+    -
+      expandable_card_library:
+        css:
+          component:
+            css/expandable-card.component.css: {}
+          state:
+            css/expandable-card.states.css: {}
+        js:
+          js/expandable-card.js: {}
+  use: "@stanford_components/molecules/expandable-card/expandable-card.html.twig"

--- a/patterns/molecules/expandable-card/js/expandable-card.js
+++ b/patterns/molecules/expandable-card/js/expandable-card.js
@@ -1,0 +1,14 @@
+(function (Drupal, $, window) {
+
+  // Execute code once the window is fully loaded.
+  $(window).load(function () {
+    $(".js-expandable-card__toggle").unbind('click').bind('click', function(e) { // expandable card
+      // Must be attached to anchor element to prevent bubbling.
+      event.stopPropagation();
+      e.preventDefault();
+      $(this).parent(".js-expandable-card").toggleClass('is-open').siblings(".js-expandable-card").toggleClass('is-hidden');
+      $(".js-section-expandable-banner").toggleClass('has-overlay');
+    });
+  });
+
+} (Drupal, jQuery, this));

--- a/patterns/molecules/expandable-card/scss/expandable-card.component.scss
+++ b/patterns/molecules/expandable-card/scss/expandable-card.component.scss
@@ -1,0 +1,65 @@
+@charset 'UTF-8';
+
+@import 'decanter/core/utilities/decanter-utilities';
+
+// Grab our mixins.
+@import 'patterns/utilities/utilities';
+
+.expandable-card {
+  background-color: color(white);
+  max-width: 285px;
+
+  // has two column layout
+  &.is-narrow {
+    .icon-item {
+      @include grid-media($media-md) {
+        @include grid-column(6);
+
+        &:nth-child(2n+1) {
+          clear: both;
+        }
+      }
+    }
+  }
+
+  // has three column layout
+  &.is-wide {
+    .icon-item {
+      @include grid-media($media-md) {
+        @include grid-column(4);
+
+        &:nth-child(3n+1) {
+          clear: both;
+        }
+      }
+    }
+  }
+
+  .icon-items {
+    @include grid-container;
+    display: none;
+  }
+
+  .icon-item {
+    display: block;
+    max-width: 180px;
+    margin: 0 auto;
+    padding: 2em 0 1em;
+
+    @include grid-media($media-md) {
+      padding: 2em 1em 1em 0;
+      max-width: none;
+    }
+  }
+}
+
+.expandable-card__open {
+  display: block;
+}
+
+.expandable-card__close {
+  display: none;
+  position: absolute;
+  top: 45px;
+  right: 30px;
+}

--- a/patterns/molecules/expandable-card/scss/expandable-card.states.scss
+++ b/patterns/molecules/expandable-card/scss/expandable-card.states.scss
@@ -1,0 +1,45 @@
+@charset 'UTF-8';
+
+@import 'decanter/core/utilities/decanter-utilities';
+
+// Grab our mixins.
+@import 'patterns/utilities/utilities';
+
+.js-expandable-card {
+  &.is-open {
+    padding: 0;
+    width: 100%;
+    max-width: none;
+
+    .expandable-card__header {
+      padding: em(8px) em(30px);
+      background-color: color(dust);
+    }
+
+    .expandable-card__title {
+      padding-top: 1em;
+      padding-bottom: 1em;
+    }
+
+    .icon-items {
+      display: block;
+      padding-bottom: 1em;
+
+      @include grid-media($media-md) {
+        padding-bottom: 0;
+      }
+    }
+
+    .expandable-card__open {
+      display: none;
+    }
+
+    .expandable-card__close {
+      display: block;
+    }
+  }
+
+  &.is-hidden {
+    display: none;
+  }
+}

--- a/patterns/molecules/expandable-cards/css/expandable-cards.component.css
+++ b/patterns/molecules/expandable-cards/css/expandable-cards.component.css
@@ -1,0 +1,22 @@
+.expandable-cards::after {
+  clear: both;
+  content: "";
+  display: block;
+}
+
+.expandable-cards .expandable-card {
+  width: 100%;
+  margin: 0 auto 2em;
+}
+
+@media only screen and (min-width: 768px) {
+  .expandable-cards .expandable-card {
+    width: calc(50% - 60px);
+    float: left;
+    margin-left: 40px;
+    min-height: 200px;
+    margin-bottom: 0;
+  }
+}
+
+/*# sourceMappingURL=expandable-cards.component.css.map */

--- a/patterns/molecules/expandable-cards/expandable-cards.html.twig
+++ b/patterns/molecules/expandable-cards/expandable-cards.html.twig
@@ -1,0 +1,24 @@
+{#
+/**
+ * @file
+ * Highlight cards pattern.
+ */
+#}
+{{ attach_library('ui_patterns/icon_item.icon_item_library') }}
+{{ attach_library('ui_patterns/expandable_card.expandable_card_library') }}
+<div class="expandable-cards">
+  {# Break up the individual items in to the appropriate template var. #}
+  {% for card in cards %}
+
+    {% set card_vars = {
+      'link': card.link,
+      'title': card.title,
+      'items': card.items,
+      'is_wide': card.is_wide
+      }
+    %}
+
+    {# Pass vars through to include template. #}
+    {% include '@stanford_components/molecules/expandable-card/expandable-card.html.twig' with card_vars %}
+  {% endfor %}
+</div>

--- a/patterns/molecules/expandable-cards/expandable-cards.ui_patterns.yml
+++ b/patterns/molecules/expandable-cards/expandable-cards.ui_patterns.yml
@@ -1,0 +1,104 @@
+# Expandable Cards Pattern
+#
+expandable_cards:
+  label: "Expandable Cards"
+  description: "A horizontal list expandable cards with icons"
+  fields:
+    cards:
+      description: "This template iterates over the items to produce a nested unordered list of divs. Each item must have a url, title, intro and description rendered as an html element."
+      label: "A list of highlight cards"
+      preview:
+        -
+          is_wide: true
+          items:
+            -
+              image:
+                alt: "this is a sample image"
+                theme: image
+                uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+              link: "https://www.stanford.edu"
+              name: "Geological Sciences"
+            -
+              image:
+                alt: "this is a sample image"
+                theme: image
+                uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+              link: "https://www.stanford.edu"
+              name: "Energy Resources Engineering"
+            -
+              image:
+                alt: "this is a sample image"
+                theme: image
+                uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+              link: "https://www.stanford.edu"
+              name: "Earth Systems Program"
+            -
+              image:
+                alt: "this is a sample image"
+                theme: image
+                uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+              link: "https://www.stanford.edu"
+              name: "Earth Systems Sciences"
+            -
+              image:
+                alt: "this is a sample image"
+                theme: image
+                uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+              link: "https://www.stanford.edu"
+              name: Geophysics
+            -
+              image:
+                alt: "this is a sample image"
+                theme: image
+                uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+              link: "https://www.stanford.edu"
+              name: "Emmett Interdisciplinary Program"
+          link: "https://www.stanford.edu"
+          title: Undergraduates
+        -
+          is_wide: false
+          items:
+            -
+              icon:
+                alt: "this is a sample image"
+                theme: image
+                uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+              link: "https://www.stanford.edu"
+              name: "Geological Sciences"
+            -
+              icon:
+                alt: "this is a sample image"
+                theme: image
+                uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+              link: "https://www.stanford.edu"
+              name: "Energy Resources Engineering"
+            -
+              icon:
+                alt: "this is a sample image"
+                theme: image
+                uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+              link: "https://www.stanford.edu"
+              name: "Earth Systems Program"
+            -
+              icon:
+                alt: "this is a sample image"
+                theme: image
+                uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+              link: "https://www.stanford.edu"
+              name: Geophysics
+            -
+              icon:
+                alt: "this is a sample image"
+                theme: image
+                uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+              link: "https://www.stanford.edu"
+              name: "Emmett Interdisciplinary Program"
+          link: "https://www.stanford.edu"
+          title: Graduates
+  libraries:
+    -
+      expandable_cards_library:
+        css:
+          component:
+            css/expandable-cards.component.css: {}
+  use: "@stanford_components/molecules/expandable-cards/expandable-cards.html.twig"

--- a/patterns/molecules/expandable-cards/scss/expandable-cards.component.scss
+++ b/patterns/molecules/expandable-cards/scss/expandable-cards.component.scss
@@ -1,0 +1,21 @@
+@charset 'UTF-8';
+
+@import 'decanter/core/utilities/decanter-utilities';
+
+// Grab our mixins.
+@import 'patterns/utilities/utilities';
+
+.expandable-cards {
+  @include grid-container;
+
+  .expandable-card {
+    width: 100%;
+    margin: 0 auto 2em;
+
+    @include grid-media($media-md) {
+      @include grid-column(6);
+      min-height: 200px;
+      margin-bottom: 0;
+    }
+  }
+}

--- a/patterns/molecules/feature-cards/css/feature-cards.component.css
+++ b/patterns/molecules/feature-cards/css/feature-cards.component.css
@@ -18,7 +18,7 @@
   }
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1024px) {
   .feature-cards .feature-card {
     width: calc(33.3333333333% - 40px);
     float: left;

--- a/patterns/molecules/filmstrip/css/filmstrip.component.css
+++ b/patterns/molecules/filmstrip/css/filmstrip.component.css
@@ -43,7 +43,7 @@
   }
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1024px) {
   .filmstrip.is-flexible .film-card {
     width: calc(25% - 15px);
     float: left;

--- a/patterns/molecules/hero-banner/css/hero-banner.component.css
+++ b/patterns/molecules/hero-banner/css/hero-banner.component.css
@@ -36,7 +36,7 @@
   }
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1024px) {
   .hero-banner__inner {
     min-height: 400px;
   }
@@ -48,7 +48,7 @@
   }
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1024px) {
   .hero-banner__inner.is-tall {
     min-height: 660px;
   }
@@ -76,7 +76,7 @@
   }
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1024px) {
   .hero-banner__header {
     width: 25%;
   }
@@ -100,7 +100,7 @@
   }
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1024px) {
   .hero-banner__header.is-right {
     margin-right: 100px;
   }

--- a/patterns/molecules/highlight-card/css/highlight-card.component.css
+++ b/patterns/molecules/highlight-card/css/highlight-card.component.css
@@ -1,0 +1,10 @@
+.highlight-card {
+  background-color: #fff;
+  max-width: 285px;
+}
+
+.highlight-card__action {
+  display: block;
+}
+
+/*# sourceMappingURL=highlight-card.component.css.map */

--- a/patterns/molecules/highlight-card/highlight-card.html.twig
+++ b/patterns/molecules/highlight-card/highlight-card.html.twig
@@ -1,0 +1,16 @@
+{#
+/**
+ * @file
+ * Highlight card pattern.
+ */
+#}
+<div class="highlight-card">
+  <a class="highlight-card__action" href="{{ link|render|striptags|trim }}">
+    <span class="highlight-card__intro">{{ intro }}</span>
+    <h4 class="highlight-card__title">{{ title }}</h4>
+    <p>{{ description }}</p>
+    <div class="highlight-card__arrow">
+      <svg class="i-svg i-svg--arrow-right"><use xlink:href="#i-arrow" xmlns:xlink="http://www.w3.org/1999/xlink"></use></svg>
+    </div>
+  </a>
+</div>

--- a/patterns/molecules/highlight-card/highlight-card.ui_patterns.yml
+++ b/patterns/molecules/highlight-card/highlight-card.ui_patterns.yml
@@ -1,0 +1,32 @@
+# Highlight Cards Pattern
+highlight_card:
+  label: "Highlight card"
+  description: "A single callout card"
+  fields:
+    description:
+      description: Description.
+      label: Title
+      preview: "Today more than 7 billion people inhabit Earth and a billion lack adequate energy, water and food."
+      type: text
+    intro:
+      description: Intro.
+      label: Title
+      preview: "Take a Course"
+      type: text
+    link:
+      description: "URI that points somewhere"
+      label: Link
+      preview: "https://stanford.edu"
+      type: url
+    title:
+      description: "Card title."
+      label: Title
+      preview: "Life At The Extremes"
+      type: text
+  libraries:
+    -
+      highlight_card_library:
+        css:
+          component:
+            css/highlight-card.component.css: {}
+  use: "@stanford_components/molecules/highlight-card/highlight-card.html.twig"

--- a/patterns/molecules/highlight-card/scss/highlight-card.component.scss
+++ b/patterns/molecules/highlight-card/scss/highlight-card.component.scss
@@ -1,0 +1,15 @@
+@charset 'UTF-8';
+
+@import 'decanter/core/utilities/decanter-utilities';
+
+// Grab our mixins.
+@import 'patterns/utilities/utilities';
+
+.highlight-card {
+  background-color: color(white);
+  max-width: 285px;
+}
+
+.highlight-card__action {
+  display: block;
+}

--- a/patterns/molecules/highlight-cards/css/highlight-cards.component.css
+++ b/patterns/molecules/highlight-cards/css/highlight-cards.component.css
@@ -1,0 +1,22 @@
+.highlight-cards::after {
+  clear: both;
+  content: "";
+  display: block;
+}
+
+.highlight-cards .highlight-card {
+  width: 100%;
+  margin: 0 auto 2em;
+}
+
+@media only screen and (min-width: 768px) {
+  .highlight-cards .highlight-card {
+    width: calc(50% - 60px);
+    float: left;
+    margin-left: 40px;
+    min-height: 200px;
+    margin-bottom: 0;
+  }
+}
+
+/*# sourceMappingURL=highlight-cards.component.css.map */

--- a/patterns/molecules/highlight-cards/highlight-cards.html.twig
+++ b/patterns/molecules/highlight-cards/highlight-cards.html.twig
@@ -1,0 +1,21 @@
+{#
+/**
+ * @file
+ * Highlight cards pattern.
+ */
+#}
+{{ attach_library('ui_patterns/callout_card.highlight_card_library') }}
+<div class="highlight-cards">
+  {# Break up the individual items in to the appropriate template var. #}
+  {% for item in items %}
+    {% set vars = {
+      'link': item.link,
+      'title': item.title,
+      'intro': item.intro,
+      'description': item.description
+      }
+    %}
+    {# Pass vars through to include template. #}
+    {% include '@stanford_components/molecules/highlight-card/highlight-card.html.twig' with vars %}
+  {% endfor %}
+</div>

--- a/patterns/molecules/highlight-cards/highlight-cards.ui_patterns.yml
+++ b/patterns/molecules/highlight-cards/highlight-cards.ui_patterns.yml
@@ -1,0 +1,27 @@
+# Highlight Cards Pattern
+#
+highlight_cards:
+  label: "Highlight Cards"
+  description: "A horizontal list callout cards with icons"
+  fields:
+    items:
+      description: "This template iterates over the items to produce a nested unordered list of divs. Each item must have a url, title, intro and description rendered as an html element."
+      label: "A list of highlight cards"
+      preview:
+        -
+          description: "Today more than 7 billion people inhabit Earth and a billion lack adequate energy, water and food."
+          intro: "Take a course"
+          link: "https://www.stanford.edu"
+          title: "Life At The Extremes"
+        -
+          description: "What do we really know about Earth's ice sheets and their influence?"
+          intro: "Attend one of our events"
+          link: "https://www.stanford.edu"
+          title: "Stanford Earth Matters San Francisco"
+  libraries:
+    -
+      highlight_cards_library:
+        css:
+          component:
+            css/highlight-cards.component.css: {}
+  use: "@stanford_components/molecules/highlight-cards/highlight-cards.html.twig"

--- a/patterns/molecules/highlight-cards/scss/highlight-cards.component.scss
+++ b/patterns/molecules/highlight-cards/scss/highlight-cards.component.scss
@@ -1,0 +1,22 @@
+@charset 'UTF-8';
+
+@import 'decanter/core/utilities/decanter-utilities';
+
+// Grab our mixins.
+@import 'patterns/utilities/utilities';
+
+.highlight-cards {
+  @include grid-container;
+
+  .highlight-card {
+    width: 100%;
+    margin: 0 auto 2em;
+
+    @include grid-media($media-md) {
+      @include grid-column(6);
+      min-height: 200px;
+      margin-bottom: 0;
+    }
+  }
+}
+

--- a/patterns/molecules/link-banner/css/link-banner.component.css
+++ b/patterns/molecules/link-banner/css/link-banner.component.css
@@ -1,0 +1,88 @@
+.link-banner {
+  background-repeat: no-repeat;
+}
+
+.link-banner::after {
+  clear: both;
+  content: "";
+  display: block;
+}
+
+@media only screen and (min-width: 1024px) {
+  .link-banner {
+    margin-right: -80px;
+    margin-left: -80px;
+    padding-left: 80px;
+    padding-right: 80px;
+  }
+}
+
+.link-banner .link-banner__header {
+  width: calc(100% - 40px);
+  float: left;
+  margin-left: 20px;
+}
+
+@media only screen and (min-width: 1024px) {
+  .link-banner .link-banner__header {
+    width: calc(25% - 50px);
+    float: left;
+    margin-left: 40px;
+    text-align: left;
+  }
+}
+
+@media only screen and (min-width: 1200px) {
+  .link-banner .link-banner__header {
+    padding-right: 3.8888888889em;
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .link-banner .link-items {
+    width: calc(100% - 80px);
+    float: left;
+    margin-left: 40px;
+    margin-left: -40px;
+    margin-right: -40px;
+    width: calc(100% + 80px);
+  }
+}
+
+@media only screen and (min-width: 1024px) {
+  .link-banner .link-items {
+    width: calc(75% - 70px);
+    float: left;
+    margin-left: 40px;
+  }
+}
+
+.link-items {
+  float: left;
+  display: block;
+  width: 100%;
+}
+
+.link-items::after {
+  clear: both;
+  content: "";
+  display: block;
+}
+
+.link-items .link-item {
+  display: block;
+  width: 100%;
+}
+
+@media only screen and (min-width: 768px) {
+  .link-items .link-item {
+    width: calc(33.3333333333% - 53.3333333333px);
+    float: left;
+    margin-left: 40px;
+  }
+  .link-items .link-item:nth-child(3n+1) {
+    clear: both;
+  }
+}
+
+/*# sourceMappingURL=link-banner.component.css.map */

--- a/patterns/molecules/link-banner/link-banner.html.twig
+++ b/patterns/molecules/link-banner/link-banner.html.twig
@@ -1,0 +1,30 @@
+{#
+/**
+ * @file
+ * Link banner pattern.
+ */
+#}
+{{ attach_library('ui_patterns/link_item.link_item_library') }}
+<div class="link-banner" style="background-image:url({{ imgurl|default('https://upload.wikimedia.org/wikipedia/commons/3/36/Hopetoun_falls.jpg') }})">
+  <header class="link-banner__header">
+    <h3>{{ title }}</h3>
+    <p>{{ description }}</p>
+  </header>
+
+  <div class="link-items">
+
+  {# Break up the individual items in to the appropriate template var. #}
+  {% for item in items %}
+
+    {% set vars = {
+      'link': item.link,
+      'title': item.title,
+      'subtitle': item.subtitle
+      }
+    %}
+
+    {# Pass vars through to include template. #}
+    {% include '@stanford_components/atoms/link-item/link-item.html.twig' with vars %}
+  {% endfor %}
+  </div>
+</div>

--- a/patterns/molecules/link-banner/link-banner.ui_patterns.yml
+++ b/patterns/molecules/link-banner/link-banner.ui_patterns.yml
@@ -1,0 +1,66 @@
+# Link Banner Pattern
+#
+link_banner:
+  label: "Link Banner"
+  description: "A grid of links on photo background"
+  fields:
+    description:
+      description: "Description for the link grid"
+      label: Description
+      preview: "Find our research and insights, organized into nine categories, at our Earth Matters research news magazine."
+      type: text
+    imgurl:
+      description: "Image background url"
+      label: "Background image url (optional)"
+      preview: ~
+    items:
+      description: "This template iterates over the items to produce a grid of links."
+      label: "A list of simple links"
+      preview:
+        -
+          link: "https://www.stanford.edu"
+          subtitle: Change
+          title: Climate
+        -
+          link: "https://www.stanford.edu"
+          subtitle: "& Agrictulture"
+          title: Food
+        -
+          link: "https://www.stanford.edu"
+          subtitle: Resources
+          title: "Fresh Water"
+        -
+          link: "https://www.stanford.edu"
+          subtitle: Earth
+          title: Dynamic
+        -
+          link: "https://www.stanford.edu"
+          subtitle: "& Sustainability"
+          title: "Human Dimensions"
+        -
+          link: "https://www.stanford.edu"
+          subtitle: "of Earth & Life"
+          title: Evolution
+        -
+          link: "https://www.stanford.edu"
+          title: Energy
+        -
+          link: "https://www.stanford.edu"
+          subtitle: Hazards
+          title: Natural
+        -
+          link: "https://www.stanford.edu"
+          title: Oceans
+      type: collection
+    title:
+      description: "Title for the link grid"
+      label: Title
+      preview: "Earth Matters"
+      type: text
+  libraries:
+    -
+      link_banner_library:
+        css:
+          component:
+            css/link-banner.component.css: {}
+  use: "@stanford_components/molecules/link-banner/link-banner.html.twig"

--- a/patterns/molecules/link-banner/scss/link-banner.component.scss
+++ b/patterns/molecules/link-banner/scss/link-banner.component.scss
@@ -1,0 +1,62 @@
+@charset 'UTF-8';
+
+@import 'decanter/core/utilities/decanter-utilities';
+
+// Grab our mixins.
+@import 'patterns/utilities/utilities';
+
+.link-banner {
+  @include grid-container;
+  background-repeat: no-repeat;
+
+  @include grid-media($media-lg) {
+    margin-right: -80px;
+    margin-left: -80px;
+    padding-left: 80px;
+    padding-right: 80px;
+  }
+
+  .link-banner__header {
+    @include grid-column(12);
+
+    @include grid-media($media-lg) {
+      @include grid-column(3);
+      text-align: left;
+    }
+
+    @include grid-media($media-xl) {
+      padding-right: em(70px);
+    }
+  }
+
+  .link-items {
+    @include grid-media($media-md) {
+      @include grid-column(12);
+      @include grid-collapse;
+    }
+
+    @include grid-media($media-lg) {
+      @include grid-column(9);
+    }
+  }
+}
+
+.link-items {
+  @include grid-container;
+  float: left;
+  display: block;
+  width: 100%;
+
+  .link-item {
+    display: block;
+    width: 100%;
+
+    @include grid-media($media-md) {
+      @include grid-column(4);
+
+      &:nth-child(3n+1) {
+        clear: both;
+      }
+    }
+  }
+}

--- a/patterns/molecules/postcard/css/postcard.component.css
+++ b/patterns/molecules/postcard/css/postcard.component.css
@@ -27,13 +27,13 @@
   }
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1024px) {
   .postcard .postcard__image {
     width: 70%;
   }
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1024px) {
   .postcard .postcard__content {
     position: relative;
     margin: 0 auto;
@@ -61,7 +61,7 @@
   }
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1024px) {
   .postcard .postcard__content-inner {
     width: 30%;
   }
@@ -88,13 +88,13 @@
   }
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1024px) {
   .postcard.has-text-offset .postcard__image {
     width: 66.666%;
   }
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1024px) {
   .postcard.has-text-offset .postcard__content-inner {
     padding: 30px 0;
     width: 33.333%;
@@ -106,27 +106,27 @@
   position: relative;
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1024px) {
   .postcard.has-text-offset .postcard__content-text {
     margin-left: -30px;
     width: calc(100% + 30px);
   }
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1024px) {
   .postcard.has-text-offset.has-image-right .postcard__content-text {
     margin-right: -30px;
     margin-left: 0;
   }
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1024px) {
   .postcard.has-text-inset .postcard__image {
     width: 60%;
   }
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1024px) {
   .postcard.has-text-inset .postcard__content-inner {
     padding: 40px;
     width: 40%;

--- a/patterns/organisms/section-callout-cards/css/section-callout-cards.component.css
+++ b/patterns/organisms/section-callout-cards/css/section-callout-cards.component.css
@@ -14,47 +14,47 @@
 
 @media only screen and (min-width: 768px) {
   .section-callout-cards .callout-cards__header {
-    width: calc(100% - 40px);
+    width: calc(100% - 80px);
     float: left;
-    margin-left: 20px;
+    margin-left: 40px;
   }
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1024px) {
   .section-callout-cards .callout-cards__header {
-    width: calc(25% - 25px);
+    width: calc(25% - 50px);
     float: left;
-    margin-left: 20px;
+    margin-left: 40px;
   }
 }
 
 @media only screen and (min-width: 1200px) {
   .section-callout-cards .callout-cards__header {
-    margin-left: calc(8.3333333333% - 21.6666666667px + 40px);
+    margin-left: calc(8.3333333333% - 65px + 120px);
   }
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1024px) {
   .section-callout-cards .callout-cards__container {
-    width: calc(75% - 35px);
+    width: calc(75% - 70px);
     float: left;
-    margin-left: 20px;
+    margin-left: 40px;
   }
 }
 
 @media only screen and (min-width: 1200px) {
   .section-callout-cards .callout-cards__container {
-    width: calc(66.6666666667% - 33.3333333333px);
+    width: calc(66.6666666667% - 100px);
     float: left;
-    margin-left: 20px;
+    margin-left: 60px;
   }
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1024px) {
   .section-callout-cards .callout-cards__container .callout-cards {
-    margin-left: -20px;
-    margin-right: -20px;
-    width: calc(100% + 40px);
+    margin-left: -40px;
+    margin-right: -40px;
+    width: calc(100% + 80px);
   }
 }
 

--- a/patterns/organisms/section-expandable-banner/css/section-expandable-banner.component.css
+++ b/patterns/organisms/section-expandable-banner/css/section-expandable-banner.component.css
@@ -1,0 +1,136 @@
+.section-expandable-banner {
+  background-size: cover;
+  padding-bottom: 1.6666666667em;
+  padding-top: 1.6666666667em;
+  position: relative;
+  margin-bottom: 58px;
+}
+
+@media only screen and (max-width: 575px) {
+  .section-expandable-banner {
+    padding: 1em calc(((50% /12) * 0) + 20px);
+  }
+  .section-expandable-banner::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+}
+
+@media only screen and (min-width: 576px) and (max-width: 767px) {
+  .section-expandable-banner {
+    padding: 1em calc(((50% /12) * 0) + 20px);
+  }
+  .section-expandable-banner::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+}
+
+@media only screen and (min-width: 768px) and (max-width: 991px) {
+  .section-expandable-banner {
+    padding: 1em calc(((50% /12) * 0) + 20px);
+  }
+  .section-expandable-banner::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+}
+
+@media only screen and (min-width: 992px) and (max-width: 1199px) {
+  .section-expandable-banner {
+    padding: 1em calc(((50% /12) * 0) + 20px);
+  }
+  .section-expandable-banner::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+}
+
+@media only screen and (min-width: 1200px) {
+  .section-expandable-banner {
+    padding: 1em calc(50% - (600px - 20px));
+  }
+  .section-expandable-banner::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+}
+
+@media only print {
+  .section-expandable-banner {
+    padding: 1em calc(((50% /12) * 0) + 0.25in);
+  }
+  .section-expandable-banner::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .section-expandable-banner {
+    display: flex;
+    align-items: center;
+  }
+}
+
+.section-expandable-banner .expandable-banner__header {
+  padding-top: 1.6666666667em;
+  width: 100%;
+}
+
+@media only screen and (min-width: 768px) {
+  .section-expandable-banner .expandable-banner__header {
+    width: calc(25% - 50px);
+    float: left;
+    margin-left: 40px;
+    padding-top: 0;
+  }
+}
+
+@media only screen and (min-width: 1024px) {
+  .section-expandable-banner .expandable-banner__header {
+    width: calc(25% - 50px);
+    float: left;
+    margin-left: 40px;
+    margin-left: calc(8.3333333333% - 43.3333333333px + 80px);
+  }
+}
+
+@media only screen and (min-width: 1200px) {
+  .section-expandable-banner .expandable-banner__header {
+    margin-left: calc(16.6666666667% - 70px + 120px);
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .section-expandable-banner .expandable-banner__container {
+    width: calc(75% - 70px);
+    float: left;
+    margin-left: 40px;
+  }
+}
+
+@media only screen and (min-width: 1024px) {
+  .section-expandable-banner .expandable-banner__container {
+    width: calc(66.6666666667% - 66.6666666667px);
+    float: left;
+    margin-left: 40px;
+    margin-left: calc(8.3333333333% - 43.3333333333px + 80px);
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .section-expandable-banner .expandable-banner__container .expandable-cards {
+    margin-left: -40px;
+    margin-right: -40px;
+    width: calc(100% + 80px);
+  }
+}
+
+/*# sourceMappingURL=section-expandable-banner.component.css.map */

--- a/patterns/organisms/section-expandable-banner/css/section-expandable-banner.states.css
+++ b/patterns/organisms/section-expandable-banner/css/section-expandable-banner.states.css
@@ -1,0 +1,41 @@
+@media only screen and (min-width: 768px) {
+  .js-section-expandable-banner.has-overlay {
+    position: relative;
+  }
+  .js-section-expandable-banner.has-overlay::before {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: rgba(0, 0, 0, 0.35);
+    content: '';
+    display: block;
+  }
+  .js-section-expandable-banner.has-overlay img {
+    display: block;
+  }
+  .js-section-expandable-banner.has-overlay .expandable-banner__header {
+    display: none;
+  }
+  .js-section-expandable-banner.has-overlay .expandable-banner__container {
+    float: none;
+    width: auto;
+    margin: -30px auto;
+  }
+  .js-section-expandable-banner.has-overlay .expandable-banner__container .expandable-cards {
+    margin: 0;
+    width: auto;
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .js-section-expandable-banner .js-expandable-card.is-open {
+    float: none;
+    z-index: 4;
+    max-width: none;
+    width: auto;
+  }
+}
+
+/*# sourceMappingURL=section-expandable-banner.states.css.map */

--- a/patterns/organisms/section-expandable-banner/scss/section-expandable-banner.component.scss
+++ b/patterns/organisms/section-expandable-banner/scss/section-expandable-banner.component.scss
@@ -1,0 +1,56 @@
+@charset 'UTF-8';
+
+@import 'decanter/core/utilities/decanter-utilities';
+
+// Grab our mixins.
+@import 'patterns/utilities/utilities';
+
+.section-expandable-banner {
+  @include responsive-container($default-container);
+  background-size: cover;
+  padding-bottom: em(30px);
+  padding-top: em(30px);
+  position: relative;
+  margin-bottom: (58px);
+
+  @include grid-media($media-md) {
+    display: flex;
+    align-items: center;
+  }
+
+  .expandable-banner__header {
+    padding-top: em(30px);
+    width: 100%;
+
+    @include grid-media($media-md) {
+      @include grid-column(3);
+      padding-top: 0;
+    }
+
+    @include grid-media($media-lg) {
+      @include grid-column(3);
+      @include grid-push(1);
+    }
+
+    @include grid-media($media-xl) {
+      @include grid-push(2);
+    }
+  }
+
+  .expandable-banner__container {
+    @include grid-media($media-md) {
+      @include grid-column(9);
+    }
+
+    @include grid-media($media-lg) {
+      @include grid-column(8);
+      @include grid-push(1);
+    }
+
+    .expandable-cards {
+      @include grid-media($media-md) {
+        @include grid-collapse;
+      }
+    }
+  }
+}

--- a/patterns/organisms/section-expandable-banner/scss/section-expandable-banner.states.scss
+++ b/patterns/organisms/section-expandable-banner/scss/section-expandable-banner.states.scss
@@ -1,0 +1,42 @@
+@charset 'UTF-8';
+
+@import 'decanter/core/utilities/decanter-utilities';
+
+// Grab our mixins.
+@import 'patterns/utilities/utilities';
+
+.js-section-expandable-banner {
+  // open state on single expandable card
+  &.has-overlay {
+    @include grid-media($media-md) {
+      @include image-overlay();
+
+      .expandable-banner__header {
+        display: none;
+      }
+
+      .expandable-banner__container {
+        float: none;
+        width: auto;
+        margin: -30px auto;
+      }
+
+      .expandable-banner__container .expandable-cards {
+        margin: 0;
+        width: auto;
+      }
+    }
+  }
+
+  // open state on single expandable card
+  .js-expandable-card {
+    &.is-open {
+      @include grid-media($media-md) {
+        float: none;
+        z-index: 4;
+        max-width: none;
+        width: auto;
+      }
+    }
+  }
+}

--- a/patterns/organisms/section-expandable-banner/section-expandable-banner.html.twig
+++ b/patterns/organisms/section-expandable-banner/section-expandable-banner.html.twig
@@ -1,0 +1,39 @@
+{#
+/**
+ * @file
+ * Expandable banner pattern.
+ */
+#}
+{{ attach_library('ui_patterns/section_header.section_header_library') }}
+{{ attach_library('ui_patterns/expandable_card.expandable_card_library') }}
+{{ attach_library('ui_patterns/expandable_cards.expandable_cards_library') }}
+<div class="section-expandable-banner js-section-expandable-banner" style="background-image:url({{ image|render|striptags|trim }})">
+  <div class="expandable-banner__header">
+    {%  set header_vars = {
+      'superhead': superhead,
+      'subhead': subhead,
+      'is-centered': is_centered,
+      'dash_under': dash_under
+    } %}
+    {% include '@stanford_components/molecules/section-header/section-header.html.twig' with header_vars %}
+  </div>
+
+  <div class="expandable-banner__container">
+    <div class="expandable-cards">
+      {# Break up the individual items in to the appropriate template var. #}
+      {% for card in cards %}
+
+        {% set card_vars = {
+          'link': card.link,
+          'title': card.title,
+          'items': card.items,
+          'is_wide': card.is_wide
+          }
+        %}
+
+        {# Pass vars through to include template. #}
+        {% include '@stanford_components/molecules/expandable-card/expandable-card.html.twig' with card_vars %}
+      {% endfor %}
+    </div>
+  </div>
+</div>

--- a/patterns/organisms/section-expandable-banner/section-expandable-banner.ui_patterns.yml
+++ b/patterns/organisms/section-expandable-banner/section-expandable-banner.ui_patterns.yml
@@ -1,0 +1,129 @@
+# Expandable Banner Pattern
+#
+section_expandable_banner:
+  label: "Section Expandable Banner"
+  description: "A banner with expandable cards and photo background"
+  fields:
+    cards:
+      description: "This template iterates over the items to produce a nested unordered list of divs. Each item must have a url, title, intro and description rendered as an html element."
+      label: "A list of highlight cards"
+      preview:
+        -
+          is_wide: true
+          items:
+            -
+              image:
+                alt: "this is a sample image"
+                theme: image
+                uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+              link: "https://www.stanford.edu"
+              name: "Geological Sciences"
+            -
+              image:
+                alt: "this is a sample image"
+                theme: image
+                uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+              link: "https://www.stanford.edu"
+              name: "Energy Resources Engineering"
+            -
+              image:
+                alt: "this is a sample image"
+                theme: image
+                uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+              link: "https://www.stanford.edu"
+              name: "Earth Systems Program"
+            -
+              image:
+                alt: "this is a sample image"
+                theme: image
+                uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+              link: "https://www.stanford.edu"
+              name: "Earth Systems Sciences"
+            -
+              image:
+                alt: "this is a sample image"
+                theme: image
+                uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+              link: "https://www.stanford.edu"
+              name: Geophysics
+            -
+              image:
+                alt: "this is a sample image"
+                theme: image
+                uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+              link: "https://www.stanford.edu"
+              name: "Emmett Interdisciplinary Program"
+          link: "https://www.stanford.edu"
+          title: Undergraduates
+        -
+          is_wide: false
+          items:
+            -
+              image:
+                alt: "this is a sample image"
+                theme: image
+                uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+              link: "https://www.stanford.edu"
+              name: "Geological Sciences"
+            -
+              image:
+                alt: "this is a sample image"
+                theme: image
+                uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+              link: "https://www.stanford.edu"
+              name: "Energy Resources Engineering"
+            -
+              image:
+                alt: "this is a sample image"
+                theme: image
+                uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+              link: "https://www.stanford.edu"
+              name: "Earth Systems Program"
+            -
+              image:
+                alt: "this is a sample image"
+                theme: image
+                uri: "https://upload.wikimedia.org/wikipedia/commons/0/0c/Rectilinear_minimum_spanning_tree.svg"
+              link: "https://www.stanford.edu"
+              name: Geophysics
+          link: "https://www.stanford.edu"
+          title: Graduates
+    dash_under:
+      description: "Emphasis dash under h2 or to the left?  Treat as boolean (true/false)"
+      label: "Dash Under Emphasis"
+      preview: false
+      type: text
+    image:
+      description: "Hero image."
+      label: "Image URL"
+      preview: "https://upload.wikimedia.org/wikipedia/commons/3/34/Rub_al_Khali_002.JPG"
+      type: text
+    is_centered:
+      description: "Flag to determine whether h2 should be centered.  Treat as boolean (true/false)."
+      label: Center
+      preview: false
+      type: text
+    is_featured:
+      description: "Emphasis has emphasis or default brand color?  Treat as boolean (true/false)"
+      label: "Dash with Emphasis"
+      preview: true
+      type: text
+    subhead:
+      description: "Card text.  Renders full html (eg. <p> & <br />)"
+      label: Subhead
+      preview: "<p>We offer BS, MS, MA, and PhD programs.</p>"
+      type: text
+    superhead:
+      description: "Title for the highlight banner."
+      label: Superhead
+      preview: "Degree Programs"
+      type: text
+  libraries:
+    -
+      section_expandable_banner_library:
+        css:
+          component:
+            css/section-expandable-banner.component.css: {}
+          state:
+            css/section-expandable-banner.states.css: {}
+  use: "@stanford_components/organisms/section-expandable-banner/section-expandable-banner.html.twig"

--- a/patterns/organisms/section-feature-cards/css/section-feature-cards.component.css
+++ b/patterns/organisms/section-feature-cards/css/section-feature-cards.component.css
@@ -15,17 +15,17 @@
 
 @media only screen and (min-width: 768px) {
   .section-feature-cards .feature-cards__header {
-    width: calc(100% - 40px);
+    width: calc(100% - 80px);
     float: left;
-    margin-left: 20px;
+    margin-left: 40px;
   }
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1024px) {
   .section-feature-cards .feature-cards__header {
-    width: calc(25% - 25px);
+    width: calc(25% - 50px);
     float: left;
-    margin-left: 20px;
+    margin-left: 40px;
   }
 }
 
@@ -35,19 +35,19 @@
   }
 }
 
-@media only screen and (min-width: 992px) {
+@media only screen and (min-width: 1024px) {
   .section-feature-cards .feature-cards__container {
-    width: calc(75% - 35px);
+    width: calc(75% - 70px);
     float: left;
-    margin-left: 20px;
+    margin-left: 40px;
   }
 }
 
 @media only screen and (min-width: 768px) {
   .section-feature-cards .feature-cards__container .feature-cards {
-    margin-left: -20px;
-    margin-right: -20px;
-    width: calc(100% + 40px);
+    margin-left: -40px;
+    margin-right: -40px;
+    width: calc(100% + 80px);
   }
 }
 

--- a/patterns/organisms/section-highlight-banner/css/section-callout-cards.component.css
+++ b/patterns/organisms/section-highlight-banner/css/section-callout-cards.component.css
@@ -1,0 +1,61 @@
+.section-callout-cards {
+  padding-bottom: 3.2222222222em;
+}
+
+.section-callout-cards::after {
+  clear: both;
+  content: "";
+  display: block;
+}
+
+.section-callout-cards .callout-cards__header {
+  width: 100%;
+}
+
+@media only screen and (min-width: 768px) {
+  .section-callout-cards .callout-cards__header {
+    width: calc(100% - 40px);
+    float: left;
+    margin-left: 20px;
+  }
+}
+
+@media only screen and (min-width: 992px) {
+  .section-callout-cards .callout-cards__header {
+    width: calc(25% - 25px);
+    float: left;
+    margin-left: 20px;
+  }
+}
+
+@media only screen and (min-width: 1200px) {
+  .section-callout-cards .callout-cards__header {
+    margin-left: calc(8.3333333333% - 21.6666666667px + 40px);
+  }
+}
+
+@media only screen and (min-width: 992px) {
+  .section-callout-cards .callout-cards__container {
+    width: calc(75% - 35px);
+    float: left;
+    margin-left: 20px;
+  }
+}
+
+@media only screen and (min-width: 1200px) {
+  .section-callout-cards .callout-cards__container {
+    width: calc(66.6666666667% - 33.3333333333px);
+    float: left;
+    margin-left: 20px;
+  }
+}
+
+@media only screen and (min-width: 992px) {
+  .section-callout-cards .callout-cards__container .callout-cards {
+    margin-left: -20px;
+    margin-right: -20px;
+    width: calc(100% + 40px);
+  }
+}
+
+/*# sourceMappingURL=section-callout-cards.component.css.map */

--- a/patterns/organisms/section-highlight-banner/css/section-highlight-banner.component.css
+++ b/patterns/organisms/section-highlight-banner/css/section-highlight-banner.component.css
@@ -1,0 +1,180 @@
+.section-highlight-banner {
+  background-size: cover;
+  padding-bottom: 1.6666666667em;
+  padding-top: 1.6666666667em;
+  position: relative;
+}
+
+@media only screen and (max-width: 575px) {
+  .section-highlight-banner {
+    padding: 1em calc(((50% /12) * 0) + 20px);
+  }
+  .section-highlight-banner::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+}
+
+@media only screen and (min-width: 576px) and (max-width: 767px) {
+  .section-highlight-banner {
+    padding: 1em calc(((50% /12) * 0) + 20px);
+  }
+  .section-highlight-banner::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+}
+
+@media only screen and (min-width: 768px) and (max-width: 991px) {
+  .section-highlight-banner {
+    padding: 1em calc(((50% /12) * 0) + 20px);
+  }
+  .section-highlight-banner::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+}
+
+@media only screen and (min-width: 992px) and (max-width: 1199px) {
+  .section-highlight-banner {
+    padding: 1em calc(((50% /12) * 0) + 20px);
+  }
+  .section-highlight-banner::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+}
+
+@media only screen and (min-width: 1200px) {
+  .section-highlight-banner {
+    padding: 1em calc(50% - (600px - 20px));
+  }
+  .section-highlight-banner::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+}
+
+@media only print {
+  .section-highlight-banner {
+    padding: 1em calc(((50% /12) * 0) + 0.25in);
+  }
+  .section-highlight-banner::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .section-highlight-banner {
+    display: flex;
+    align-items: center;
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .section-highlight-banner.is-single .highlight-banner__header {
+    width: calc(33.3333333333% - 53.3333333333px);
+    float: left;
+    margin-left: 40px;
+    margin-left: calc(8.3333333333% - 43.3333333333px + 80px);
+  }
+}
+
+@media only screen and (min-width: 1024px) {
+  .section-highlight-banner.is-single .highlight-banner__header {
+    width: calc(33.3333333333% - 53.3333333333px);
+    float: left;
+    margin-left: 40px;
+    margin-left: calc(25% - 50px + 80px);
+  }
+}
+
+@media only screen and (min-width: 1024px) {
+  .section-highlight-banner.is-single .highlight-banner__container {
+    margin-left: calc(0% - 40px + 80px);
+  }
+}
+
+@media only screen and (min-width: 1200px) {
+  .section-highlight-banner.is-single .highlight-banner__container {
+    margin-left: calc(0% - 60px + 120px);
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .section-highlight-banner.is-single .highlight-cards .highlight-card {
+    width: calc(83.3333333333% - 73.3333333333px);
+    float: left;
+    margin-left: 40px;
+  }
+}
+
+.section-highlight-banner .highlight-banner__header {
+  position: relative;
+  padding-top: 1.6666666667em;
+  width: 100%;
+  z-index: 2;
+}
+
+@media only screen and (min-width: 768px) {
+  .section-highlight-banner .highlight-banner__header {
+    width: calc(25% - 50px);
+    float: left;
+    margin-left: 40px;
+    padding-top: 0;
+  }
+}
+
+@media only screen and (min-width: 1024px) {
+  .section-highlight-banner .highlight-banner__header {
+    width: calc(25% - 50px);
+    float: left;
+    margin-left: 40px;
+    margin-left: calc(8.3333333333% - 43.3333333333px + 80px);
+  }
+}
+
+@media only screen and (min-width: 1200px) {
+  .section-highlight-banner .highlight-banner__header {
+    margin-left: calc(16.6666666667% - 70px + 120px);
+  }
+}
+
+.section-highlight-banner .highlight-banner__container {
+  position: relative;
+  z-index: 2;
+}
+
+@media only screen and (min-width: 768px) {
+  .section-highlight-banner .highlight-banner__container {
+    width: calc(75% - 70px);
+    float: left;
+    margin-left: 40px;
+  }
+}
+
+@media only screen and (min-width: 1024px) {
+  .section-highlight-banner .highlight-banner__container {
+    width: calc(66.6666666667% - 66.6666666667px);
+    float: left;
+    margin-left: 40px;
+    margin-left: calc(8.3333333333% - 43.3333333333px + 80px);
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .section-highlight-banner .highlight-banner__container .highlight-cards {
+    margin-left: -40px;
+    margin-right: -40px;
+    width: calc(100% + 80px);
+  }
+}
+
+/*# sourceMappingURL=section-highlight-banner.component.css.map */

--- a/patterns/organisms/section-highlight-banner/scss/section-highlight-banner.component.scss
+++ b/patterns/organisms/section-highlight-banner/scss/section-highlight-banner.component.scss
@@ -1,0 +1,91 @@
+@charset 'UTF-8';
+
+@import 'decanter/core/utilities/decanter-utilities';
+
+// Grab our mixins.
+@import 'patterns/utilities/utilities';
+
+.section-highlight-banner {
+  @include responsive-container($default-container);
+  background-size: cover;
+  padding-bottom: em(30px);
+  padding-top: em(30px);
+  position: relative;
+
+  @include grid-media($media-md) {
+    display: flex;
+    align-items: center;
+  }
+
+  // If single card apply variant layout
+  &.is-single {
+    .highlight-banner__header {
+      @include grid-media($media-md) {
+        @include grid-column(4);
+        @include grid-push(1);
+      }
+
+      @include grid-media($media-lg) {
+        @include grid-column(4);
+        @include grid-push(3);
+      }
+    }
+
+    .highlight-banner__container {
+      @include grid-media($media-lg) {
+        @include grid-push(0);
+      }
+
+      @include grid-media($media-xl) {
+        @include grid-push(0);
+      }
+    }
+
+    .highlight-cards .highlight-card {
+      @include grid-media($media-md) {
+        @include grid-column(10);
+      }
+    }
+  }
+
+  .highlight-banner__header {
+    position: relative;
+    padding-top: em(30px);
+    width: 100%;
+    z-index: 2;
+
+    @include grid-media($media-md) {
+      @include grid-column(3);
+      padding-top: 0;
+    }
+
+    @include grid-media($media-lg) {
+      @include grid-column(3);
+      @include grid-push(1);
+    }
+
+    @include grid-media($media-xl) {
+      @include grid-push(2);
+    }
+  }
+
+  .highlight-banner__container {
+    position: relative;
+    z-index: 2;
+
+    @include grid-media($media-md) {
+      @include grid-column(9);
+    }
+
+    @include grid-media($media-lg) {
+      @include grid-column(8);
+      @include grid-push(1);
+    }
+
+    .highlight-cards {
+      @include grid-media($media-md) {
+        @include grid-collapse;
+      }
+    }
+  }
+}

--- a/patterns/organisms/section-highlight-banner/section-highlight-banner.html.twig
+++ b/patterns/organisms/section-highlight-banner/section-highlight-banner.html.twig
@@ -1,0 +1,40 @@
+{#
+/**
+ * @file
+ * Highlight banner pattern.
+ */
+#}
+{{ attach_library('ui_patterns/section_header.section_header_library') }}
+{{ attach_library('ui_patterns/highlight_card.highlight_card_library') }}
+{{ attach_library('ui_patterns/highlight_cards.highlight_cards_library') }}
+
+<div class="section-highlight-banner{% if is_single %} is-single{% endif %}"style="background-image:url({{ image|render|striptags|trim }})">
+  <div class="highlight-banner__header">
+    {%  set header_vars = {
+      'superhead': superhead,
+      'subhead': subhead,
+      'is-centered': is_centered,
+      'dash_under': dash_under
+      }
+    %}
+    {# Pass vars through to include template. #}
+    {% include '@stanford_components/molecules/section-header/section-header.html.twig' with header_vars %}
+  </div>
+
+  <div class="highlight-banner__container">
+    <div class="highlight-cards">
+      {# Break up the individual items in to the appropriate template var. #}
+      {% for item in items %}
+        {% set vars = {
+          'link': item.link,
+          'title': item.title,
+          'intro': item.intro,
+          'description': item.description
+          }
+        %}
+        {# Pass vars through to include template. #}
+        {% include '@stanford_components/molecules/highlight-card/highlight-card.html.twig' with vars %}
+      {% endfor %}
+    </div>
+  </div>
+</div>

--- a/patterns/organisms/section-highlight-banner/section-highlight-banner.ui_patterns.yml
+++ b/patterns/organisms/section-highlight-banner/section-highlight-banner.ui_patterns.yml
@@ -1,0 +1,58 @@
+# Highlight Banner Pattern
+#
+section_highlight_banner:
+  label: "Section Highlight Banner"
+  description: "A banner with highlight cards and photo background"
+  fields:
+    dash_under:
+      description: "Emphasis dash under h2 or to the left?  Treat as boolean (true/false)"
+      label: "Dash Under Emphasis"
+      preview: false
+      type: text
+    image:
+      description: "Hero image."
+      label: "Image URL"
+      preview: "https://i.ytimg.com/vi/MwKZLFYLRSs/maxresdefault.jpg"
+      type: text
+    is_centered:
+      description: "Flag to determine whether h2 should be centered.  Treat as boolean (true/false)."
+      label: Center
+      preview: false
+      type: text
+    is_featured:
+      description: "Emphasis has emphasis or default brand color?  Treat as boolean (true/false)"
+      label: "Dash with Emphasis"
+      preview: true
+      type: text
+    is_single:
+      description: "If banner has a single card adjust layout Treat as boolean (true/false)"
+      label: "If Banner only has one card"
+      preview: false
+      type: text
+    items:
+      description: "This template iterates over the items to produce a nested unordered list of divs. Each item must have a url, title, intro and description rendered as an html element."
+      label: "A list of highlight cards"
+      preview:
+        -
+          description: "Today more than 7 billion people inhabit Earth and a billion lack adequate energy, water and food."
+          intro: "Take a course"
+          link: "https://www.stanford.edu"
+          title: "Life At The Extremes"
+        -
+          description: "What do we really know about Earth's ice sheets and their influence?"
+          intro: "Attend one of our events"
+          link: "https://www.stanford.edu"
+          title: "Stanford Earth Matters San Francisco"
+      type: collection
+    superhead:
+      description: "Title for the highlight banner."
+      label: Superhead
+      preview: "Know Your Planet: Take a Course"
+      type: text
+  libraries:
+    -
+      section_highlight_banner_library:
+        css:
+          component:
+            css/section-highlight-banner.component.css: {}
+  use: "@stanford_components/organisms/section-highlight-banner/section-highlight-banner.html.twig"

--- a/patterns/templates/paragraph-cta-list/css/paragraph-cta-list.component.css
+++ b/patterns/templates/paragraph-cta-list/css/paragraph-cta-list.component.css
@@ -1,0 +1,67 @@
+@media only screen and (max-width: 575px) {
+  .paragraph__cta-list {
+    padding: 1em calc(((50% /12) * 0) + 20px);
+  }
+  .paragraph__cta-list::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+}
+
+@media only screen and (min-width: 576px) and (max-width: 767px) {
+  .paragraph__cta-list {
+    padding: 1em calc(((50% /12) * 0) + 20px);
+  }
+  .paragraph__cta-list::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+}
+
+@media only screen and (min-width: 768px) and (max-width: 1023px) {
+  .paragraph__cta-list {
+    padding: 1em calc(((50% /12) * 0) + 40px);
+  }
+  .paragraph__cta-list::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+}
+
+@media only screen and (min-width: 1024px) and (max-width: 1499px) {
+  .paragraph__cta-list {
+    padding: 1em calc(((50% /12) * 0) + 40px);
+  }
+  .paragraph__cta-list::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+}
+
+@media only screen and (min-width: 1500px) {
+  .paragraph__cta-list {
+    padding: 1em calc(50% - (750px - 60px));
+  }
+  .paragraph__cta-list::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+}
+
+@media only print {
+  .paragraph__cta-list {
+    padding: 1em calc(((50% /12) * 0) + 0.25in);
+  }
+  .paragraph__cta-list::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+}
+
+/*# sourceMappingURL=paragraph-cta-list.component.css.map */

--- a/patterns/templates/paragraph-cta-list/paragraph-cta-list.html.twig
+++ b/patterns/templates/paragraph-cta-list/paragraph-cta-list.html.twig
@@ -1,0 +1,12 @@
+{#
+/**
+ * @file
+ * Paragraph CTA List
+ */
+#}
+{# Attach the film card css and js #}
+{{ attach_library('ui_patterns/filmstrip.filmstrip_library') }}
+<div class="paragraph__cta-list">
+{% embed "@stanford_components/molecules/filmstrip/filmstrip.html.twig" ignore missing %}
+{% endembed %}
+</div>

--- a/patterns/templates/paragraph-cta-list/paragraph-cta-list.ui_patterns.yml
+++ b/patterns/templates/paragraph-cta-list/paragraph-cta-list.ui_patterns.yml
@@ -1,8 +1,8 @@
-# Filmstrip Pattern
+# Paragraph CTA List
 #
-filmstrip:
-  label: Filmstrip
-  description: "A horizontal list of small images with text overlays and arrow buttons."
+paragraph_cta_list:
+  label: Paragraph CTA List Template
+  description: "Template for the CTA List paragraph Type."
   fields:
     content:
       description: "The rendered html markup for the items if using a view or something else that will already provide the templated output."
@@ -61,8 +61,8 @@ filmstrip:
       type: text
   libraries:
     -
-      filmstrip_library:
+      paragraph_cta_list_library:
         css:
           component:
-            css/filmstrip.component.css: {}
-  use: "@stanford_components/molecules/filmstrip/filmstrip.html.twig"
+            css/paragraph-cta-list.component.css: {}
+  use: "@stanford_components/templates/paragraph-cta-list/paragraph-cta-list.html.twig"

--- a/patterns/templates/paragraph-cta-list/scss/paragraph-cta-list.component.scss
+++ b/patterns/templates/paragraph-cta-list/scss/paragraph-cta-list.component.scss
@@ -1,0 +1,9 @@
+@charset 'UTF-8';
+
+// Grab our settings.
+@import 'patterns/utilities/utilities';
+@import 'decanter/core/utilities/decanter-utilities';
+
+.paragraph__cta-list {
+  @include responsive-container($default-container);
+}

--- a/patterns/utilities/config/_global-settings.scss
+++ b/patterns/utilities/config/_global-settings.scss
@@ -1,0 +1,169 @@
+@charset "UTF-8";
+
+/// Decanter global default settings
+$decanter-default-settings: (
+  root-font-size: 10px,
+  base-font-size: 18px,
+  modular-scale-ratio: 1.25,
+  columns: 12,
+  gutter: 20px,
+  max-container-width: 1500px,
+  breakpoint-helper: false,
+  breakpoint-helper-selector: #breakpoint-helper,
+) !default;
+
+/// @name Bourbon Settings
+///
+/// @type map
+///
+/// @property {color} contrast-switch-dark-color [#000]
+///   Global dark color for the `contrast-switch` function.
+///
+/// @property {color} contrast-switch-light-color [#fff]
+///   Global light color for the `contrast-switch` function.
+///
+/// @property {list} global-font-file-formats [("ttf", "woff2", "woff")]
+///   Global font file formats for the `font-face` mixin.
+///
+/// @property {number (with unit)} modular-scale-base [1em]
+///   Global base value for the `modular-scale` function.
+///
+/// @property {number (unitless)} modular-scale-ratio [$major-third (1.25)]
+///   Global base ratio for the `modular-scale` function.
+///
+/// @property {boolean} rails-asset-pipeline [false]
+///   Set this to `true` when using the Rails Asset Pipeline and Bourbon will
+///   write asset paths using
+///   [sass-rails’ asset helpers](https://github.com/rails/sass-rails#asset-helpers).
+///
+/// @example scss
+///   $bourbon: (
+///     "contrast-switch-dark-color": #000,
+///     "contrast-switch-light-color": #fff,
+///     "global-font-file-formats": ("ttf", "woff2", "woff"),
+///     "modular-scale-base": 1em,
+///     "modular-scale-ratio": $major-third,
+///     "rails-asset-pipeline": false,
+///   );
+///
+/// @group settings
+$bourbon: (
+    "modular-scale-ratio": 1.25,
+);
+
+/// This variable is a sass map that overrides Neat's default grid settings.
+/// Use this to define your project's grid properties incluting gutters and
+/// total column count.
+///
+/// @type map
+///
+/// @name Neat grid
+///
+/// @property {number (unitless)} columns [12]
+///   Default number of the total grid columns.
+///
+/// @property {number (with unit)} gutter [20px]
+///   Default grid gutter width between columns.
+///
+/// @property {string | number (with unit)} media [null]
+///   Grid media query.
+///
+/// @property {color} color [rgba(#00d4ff, 0.25)]
+///   Default visual grid color.
+///
+/// @example scss
+///   $neat-grid: (
+///     columns: 12,
+///     gutter: 20px,
+///   );
+///
+/// @group settings
+$neat-grid: (
+    columns: map_get($decanter-default-settings, columns),
+    gutter:  map_get($decanter-default-settings, gutter),
+    media: null,
+    color: rgba(#00d4ff, 0.25),
+    direction: ltr,
+);
+
+// Lower boundaries
+// ----------------
+
+/// Screen XS Min
+$screen-xs-min:               0px;
+
+/// Screen SM Min
+$screen-sm-min:               576px;
+
+/// Screen MD Min
+$screen-md-min:               768px;
+
+/// Screen LG Min
+$screen-lg-min:               1024px;
+
+/// Screen XL Min
+$screen-xl-min:               map_get($decanter-default-settings, max-container-width) !default;
+
+// Upper boundaries
+// ----------------
+
+/// Screen XS Max
+$screen-xs-max:               $screen-sm-min - 1px;
+
+/// Screen SM Max
+$screen-sm-max:               $screen-md-min - 1px;
+
+/// Screen MD Max
+$screen-md-max:               $screen-lg-min - 1px;
+
+/// Screen LG Max
+$screen-lg-max:               $screen-xl-min - 1px;
+
+/// Media MD
+$media-md: (
+    columns: 12,
+    gutter: 40px,
+    media: $screen-md-min,
+);
+
+/// Media MD only
+$media-md-only: (
+    columns: 12,
+    gutter: 40px,
+    media: 'only screen and (min-width: #{$screen-md-min}) and (max-width: #{$screen-md-max})',
+);
+
+/// Media MD max
+$media-md-max: (
+    columns: 12,
+    gutter: 40px,
+    media: 'only screen and (max-width: #{$screen-md-max})',
+);
+
+/// Media LG
+$media-lg: (
+    columns: 12,
+    gutter: 40px,
+    media: $screen-lg-min,
+);
+
+/// Media LG only
+$media-lg-only: (
+    columns: 12,
+    gutter: 40px,
+    media: 'only screen and (min-width: #{$screen-lg-min}) and (max-width: #{$screen-lg-max})',
+);
+
+/// Media LG max
+$media-lg-max: (
+    columns: 12,
+    gutter: 40px,
+    media: 'only screen and (max-width: #{$screen-lg-max})',
+);
+
+/// Media XL
+$media-xl: (
+    columns: 12,
+    gutter: 60px,
+    media: $screen-xl-min,
+);

--- a/patterns/utilities/config/config.scss
+++ b/patterns/utilities/config/config.scss
@@ -1,0 +1,3 @@
+@charset "UTF-8";
+
+@import "global-settings";

--- a/patterns/utilities/utilities.scss
+++ b/patterns/utilities/utilities.scss
@@ -1,4 +1,6 @@
 @charset 'UTF-8';
 
-@import 'placeholders/placeholders';
-@import 'mixins/mixins';
+@import
+  'config/config',
+  'mixins/mixins',
+  'placeholders/placeholders';


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- A new centered template for the CTA List paragraph
- Updates to the grid settings that match Matson

# Needed By (Date)
- End of sprint

# Urgency
- Moderate

# Steps to Test

1. Check out this branch
2. Check out EARTH-138 on stanford_paragraph_types
3. Import all the feature code `drush features-import-all`
4. Create a CTA list paragraph
5. Review centered template

# Associated Issues and/or People
- EARTH-138
- Matson has a PR
- stanford_paragraph_types has a PR

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)